### PR TITLE
Make authorizationParams usable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 # Node.js
 node_modules
 npm-debug.log
+.idea

--- a/.npmignore
+++ b/.npmignore
@@ -14,3 +14,6 @@ npm-debug.log
 
 # Git
 .git*
+
+# IntelliJ / WebStorm
+.idea

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Passport-OpenID Connect
+# OpenID Connect for Passport
 
 [Passport](https://github.com/jaredhanson/passport) strategy for authenticating
 with [OpenID Connect](http://openid.net/connect/).
@@ -9,12 +9,17 @@ easily and unobtrusively integrated into any application or framework that
 supports [Connect](http://www.senchalabs.org/connect/)-style middleware,
 including [Express](http://expressjs.com/).
 
+Based on the [Passport-OpenID Connect](https://github.com/jaredhanson/passport-openidconnect) module by Jared Hanson that does not seem to be developed any further.
+
 ## Credits
 
   - [Jared Hanson](http://github.com/jaredhanson)
+  - [Nicole Rauch](http://github.com/nicolerauch)
 
 ## License
 
 [The MIT License](http://opensource.org/licenses/MIT)
 
 Copyright (c) 2011-2013 Jared Hanson <[http://jaredhanson.net/](http://jaredhanson.net/)>
+
+Copyright (c) 2014-2015 Nicole Rauch <[http://nicolerauch.de/](http://nicolerauch.de/)>

--- a/lib/debug_log.js
+++ b/lib/debug_log.js
@@ -1,0 +1,9 @@
+
+
+var log_to_console = function (message) {
+  console.log(message);
+};
+
+var no_op = function () {};
+
+module.exports = (process.env.NODE_ENV !== 'production' || process.env.DEBUG) ? log_to_console : no_op;

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -1,8 +1,9 @@
-var configuration = require('./configuration').configuration;
+var configuration = require('./configuration').configuration
+  , debug_log = require('./debug_log');
 
 exports = module.exports = function(identifier, done) {
-  console.log('OpenID Discovery...');
-  console.log('  identifer: ' + identifier);
+  debug_log('OpenID Discovery...');
+  debug_log('  identifer: ' + identifier);
   
   exports.discovery(identifier, function(err, issuer) {
     if (err) { return done(err); }
@@ -10,8 +11,8 @@ exports = module.exports = function(identifier, done) {
     exports.configuration(issuer, function(err, config) {
       if (err) { return done(err); };
       
-      console.log('CONFIG:');
-      console.log(config);
+      debug_log('CONFIG:');
+      debug_log(config);
       
       if (config.clientID) {
         // If the configuration contains a client ID, setup is complete and
@@ -50,8 +51,8 @@ exports.discovery = function(identifier, done) {
     // NOTE: `err` is ignored so that fallback discovery mechanisms will be
     //       attempted.
     if (err) {
-      console.log('discovery attempt failed...');
-      console.log(err);
+      debug_log('discovery attempt failed...');
+      debug_log(err);
     }
     // issuer was obtained, done
     if (issuer) { return done(null, issuer); }

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -8,7 +8,8 @@ var passport = require('passport')
   , utils = require('./utils')
   , OAuth2 = require('oauth').OAuth2
   , setup = require('./setup')
-  , InternalOAuthError = require('./errors/internaloautherror');
+  , InternalOAuthError = require('./errors/internaloautherror')
+  , debug_log = require('./debug_log');
 
 
 /**
@@ -98,11 +99,11 @@ Strategy.prototype.authenticate = function(req, options) {
       oauth2.getOAuthAccessToken(code, { grant_type: 'authorization_code', redirect_uri: callbackURL }, function(err, accessToken, refreshToken, params) {
         if (err) { return self.error(new InternalOAuthError('failed to obtain access token', err)); }
         
-        console.log('TOKEN');
-        console.log('AT: ' + accessToken);
-        console.log('RT: ' + refreshToken);
-        console.log(params);
-        console.log('----');
+        debug_log('TOKEN');
+        debug_log('AT: ' + accessToken);
+        debug_log('RT: ' + refreshToken);
+        debug_log(params);
+        debug_log('----');
         
         var idToken = params['id_token'];
         if (!idToken) { return self.error(new Error('ID Token not present in token response')); }
@@ -118,7 +119,7 @@ Strategy.prototype.authenticate = function(req, options) {
           return self.error(ex);
         }
         
-        console.log(jwtClaims);
+        debug_log(jwtClaims);
         
         var iss = jwtClaims.iss;
         var sub = jwtClaims.sub;
@@ -157,9 +158,9 @@ Strategy.prototype.authenticate = function(req, options) {
             oauth2._request("GET", userInfoURL, { 'Authorization': "Bearer " + accessToken, 'Accept': "application/json" }, null, null, function (err, body, res) {
               if (err) { return self.error(new InternalOAuthError('failed to fetch user profile', err)); }
               
-              console.log('PROFILE');
-              console.log(body);
-              console.log('-------');
+              debug_log('PROFILE');
+              debug_log(body);
+              debug_log('-------');
               
               var profile = {};
               

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -258,7 +258,6 @@ Strategy.prototype.authenticate = function(req, options) {
       }
       
       var params = self.authorizationParams(options);
-      var params = {};
       params['response_type'] = 'code';
       params['client_id'] = config.clientID;
       params['redirect_uri'] = callbackURL;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openidconnect-for-passport",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "OpenID Connect authentication strategy for Passport.",
   "keywords": ["passport", "openid", "openidconnect", "auth", "authn", "authentication", "identity"],
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,20 +1,27 @@
 {
-  "name": "passport-openidconnect",
+  "name": "openidconnect-for-passport",
   "version": "0.0.1",
   "description": "OpenID Connect authentication strategy for Passport.",
   "keywords": ["passport", "openid", "openidconnect", "auth", "authn", "authentication", "identity"],
   "repository": {
     "type": "git",
-    "url": "git://github.com/jaredhanson/passport-openidconnect.git"
+    "url": "git://github.com/nicolerauch/openidconnect-for-passport.git"
   },
   "bugs": {
-    "url": "http://github.com/jaredhanson/passport-openidconnect/issues"
+    "url": "http://github.com/nicolerauch/openidconnect-for-passport/issues"
   },
   "author": {
     "name": "Jared Hanson",
     "email": "jaredhanson@gmail.com",
     "url": "http://www.jaredhanson.net/"
   },
+  "contributors": [
+    {
+      "name": "Nicole Rauch",
+      "email": "nicole.m@gmx.de",
+      "url": "http://www.nicole-rauch.de"
+    }
+  ],
   "licenses": [ {
     "type": "MIT",
     "url": "http://www.opensource.org/licenses/MIT" 
@@ -33,5 +40,5 @@
   "scripts": {
     "test": "NODE_PATH=./lib node_modules/.bin/mocha --reporter spec --require test/node/bootstrap test/*.test.js"
   },
-  "engines": { "node": ">= 0.6.0" }
+  "engines": { "node": ">= 0.10.0" }
 }


### PR DESCRIPTION
In the strategy, the variable "params" was redeclared after it was retrieved from the authorizationParams() method. This kept users of the strategy from adding non-standard parameters to the authentication request. Removing the redeclaration of the variable made the method authorizationParams() usable.