### PR TITLE
Allow for extending `. authorizationParams()`, uncomment support for options.state

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -271,10 +271,10 @@ Strategy.prototype.authenticate = function(req, options) {
       // TODO: Add support for automatically generating a random state for verification.
       // TODO: Make state optional, if `config` disables it and supplies an alternative
       //       session key.
-      //var state = options.state;
-      //if (state) { params.state = state; }
+      // var state = utils.uid(16);
+      var state = options.state;
+      if (state) { params.state = state; }
       
-      var state = utils.uid(16);
       
       // TODO: Implement support for standard OpenID Connect params (display, prompt, etc.)
       

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -258,7 +258,6 @@ Strategy.prototype.authenticate = function(req, options) {
       }
       
       var params = self.authorizationParams(options);
-      var params = {};
       params['response_type'] = 'code';
       params['client_id'] = config.clientID;
       params['redirect_uri'] = callbackURL;


### PR DESCRIPTION
I am using this library and found this changeset useful.
* I subclassed strategy and overwrote `#authorizationParams` to specify `prompt`
* I make use of `.authenticate({ state })` to embed a destination redirect_uri in state

Are you accepting PRs? I can also make a PR to remove unnecessary console.logs. If you'd prefer a fork, I'll do that too.