### PR TITLE
Pass preconfigure options to authenticate in addition to constructor

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -237,6 +237,21 @@ Strategy.prototype.authenticate = function(req, options) {
     // discovered dynamically.  When using dynamic discovery, a user supplies
     // their identifer as input.
   
+    if (options.authorizationURL && options.tokenURL) {
+      // This OpenID Connect strategy is configured to work with a specific
+      // provider.  Override the discovery process with pre-configured endpoints.
+      this.configure(function(identifier, done) {
+        return done(null, {
+          authorizationURL: options.authorizationURL,
+          tokenURL: options.tokenURL,
+          userInfoURL: options.userInfoURL,
+          clientID: options.clientID,
+          clientSecret: options.clientSecret,
+          callbackURL: options.callbackURL
+        });
+      });
+    }
+
     var identifier;
     if (req.body && req.body[this._identifierField]) {
       identifier = req.body[this._identifierField];

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -40,22 +40,22 @@ function Strategy(options, verify) {
   if (options.authorizationURL && options.tokenURL) {
     // This OpenID Connect strategy is configured to work with a specific
     // provider.  Override the discovery process with pre-configured endpoints.
-    this.configure(function(identifier, done) {
-      return done(null, {
-        authorizationURL: options.authorizationURL,
-        tokenURL: options.tokenURL,
-        userInfoURL: options.userInfoURL,
-        clientID: options.clientID,
-        clientSecret: options.clientSecret,
-        callbackURL: options.callbackURL
-      });
-    });
+    this._configObj['default'] = {
+      authorizationURL: options.authorizationURL,
+      tokenURL: options.tokenURL,
+      userInfoURL: options.userInfoURL,
+      clientID: options.clientID,
+      clientSecret: options.clientSecret,
+      callbackURL: options.callbackURL
+    }
   }
 
   var stack = this._configObj;
   this.configure(function(identifier, done) {
     if (stack.hasOwnProperty(identifier)) {
-      return done(null, this._configObj[identifier]);
+      return done(null, stack[identifier]);
+    } else if (stack.hasOwnProperty('default')) {
+      return done(null, stack['default']);
     }
   });
 }
@@ -250,13 +250,15 @@ Strategy.prototype.authenticate = function(req, options) {
       identifier = req.body[this._identifierField];
     } else if (req.query && req.query[this._identifierField]) {
       identifier = req.query[this._identifierField];
-    } else if (options[this._identifierField]) {
-      identifier = options[this._identifierField];
     }
   
     if (options.authorizationURL && options.tokenURL) {
       // This OpenID Connect strategy is configured to work with a specific
       // provider.  Override the discovery process with pre-configured endpoints.
+      if (! identifier) {
+        identifier = options.clientID;
+      }
+
       this._configObj[identifier] = {
         authorizationURL: options.authorizationURL,
         tokenURL: options.tokenURL,

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -35,7 +35,8 @@ function Strategy(options, verify) {
   this._skipUserProfile = (options.skipUserProfile === undefined) ? false : options.skipUserProfile;
   
   this._configurers = [];
-  
+  this._configObj = {};
+
   if (options.authorizationURL && options.tokenURL) {
     // This OpenID Connect strategy is configured to work with a specific
     // provider.  Override the discovery process with pre-configured endpoints.
@@ -50,6 +51,13 @@ function Strategy(options, verify) {
       });
     });
   }
+
+  var stack = this._configObj;
+  this.configure(function(identifier, done) {
+    if (stack.hasOwnProperty(identifier)) {
+      return done(null, this._configObj[identifier]);
+    }
+  });
 }
 
 /**
@@ -236,29 +244,29 @@ Strategy.prototype.authenticate = function(req, options) {
     // be loaded.  The configuration is typically either pre-configured or
     // discovered dynamically.  When using dynamic discovery, a user supplies
     // their identifer as input.
-  
-    if (options.authorizationURL && options.tokenURL) {
-      // This OpenID Connect strategy is configured to work with a specific
-      // provider.  Override the discovery process with pre-configured endpoints.
-      this.configure(function(identifier, done) {
-        return done(null, {
-          authorizationURL: options.authorizationURL,
-          tokenURL: options.tokenURL,
-          userInfoURL: options.userInfoURL,
-          clientID: options.clientID,
-          clientSecret: options.clientSecret,
-          callbackURL: options.callbackURL
-        });
-      });
-    }
 
     var identifier;
     if (req.body && req.body[this._identifierField]) {
       identifier = req.body[this._identifierField];
     } else if (req.query && req.query[this._identifierField]) {
       identifier = req.query[this._identifierField];
+    } else if (options[this._identifierField]) {
+      identifier = options[this._identifierField];
     }
   
+    if (options.authorizationURL && options.tokenURL) {
+      // This OpenID Connect strategy is configured to work with a specific
+      // provider.  Override the discovery process with pre-configured endpoints.
+      this._configObj[identifier] = {
+        authorizationURL: options.authorizationURL,
+        tokenURL: options.tokenURL,
+        userInfoURL: options.userInfoURL,
+        clientID: options.clientID,
+        clientSecret: options.clientSecret,
+        callbackURL: options.callbackURL
+      }
+    }
+
     this.configure(identifier, function(err, config) {
       if (err) { return self.error(err); }
       

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -86,8 +86,8 @@ Strategy.prototype.authenticate = function(req, options) {
   
   if (req.query && req.query.code) {
     var code = req.query.code;
-    
-    this.configure(null, function(err, config) {
+
+    this.configure(options.clientID, function(err, config) {
       if (err) { return self.error(err); }
     
       var oauth2 = new OAuth2(config.clientID,  config.clientSecret,


### PR DESCRIPTION
I had a need to be able to configure for multiple clients, but which client isn't known until the point that authenticate is called.  These changes let you pass those options to authenticate just like you do to the constructor.
