### PR TITLE
Adding option to set passport name, to enable multiple strategies.

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -24,18 +24,18 @@ var passport = require('passport')
 function Strategy(options, verify) {
   options = options || {}
   passport.Strategy.call(this);
-  this.name = 'openidconnect';
+  this.name = options.name || 'openidconnect';
   this._verify = verify;
-  
+
   // TODO: What's the recommended field name for OpenID Connect?
   this._identifierField = options.identifierField || 'openid_identifier';
   this._scope = options.scope;
   this._scopeSeparator = options.scopeSeparator || ' ';
   this._passReqToCallback = options.passReqToCallback;
   this._skipUserProfile = (options.skipUserProfile === undefined) ? false : options.skipUserProfile;
-  
+
   this._configurers = [];
-  
+
   if (options.authorizationURL && options.tokenURL) {
     // This OpenID Connect strategy is configured to work with a specific
     // provider.  Override the discovery process with pre-configured endpoints.
@@ -68,23 +68,23 @@ util.inherits(Strategy, passport.Strategy);
 Strategy.prototype.authenticate = function(req, options) {
   options = options || {};
   var self = this;
-  
+
   if (req.query && req.query.error) {
     // TODO: Error information pertaining to OAuth 2.0 flows is encoded in the
     //       query parameters, and should be propagated to the application.
     return this.fail();
   }
-  
-  
+
+
   if (req.query && req.query.code) {
     var code = req.query.code;
-    
+
     this.configure(null, function(err, config) {
       if (err) { return self.error(err); }
-    
+
       var oauth2 = new OAuth2(config.clientID,  config.clientSecret,
                               '', config.authorizationURL, config.tokenURL);
-                              
+
       var callbackURL = options.callbackURL || config.callbackURL;
       if (callbackURL) {
         var parsed = url.parse(callbackURL);
@@ -94,32 +94,32 @@ Strategy.prototype.authenticate = function(req, options) {
           callbackURL = url.resolve(utils.originalURL(req), callbackURL);
         }
       }
-      
+
       oauth2.getOAuthAccessToken(code, { grant_type: 'authorization_code', redirect_uri: callbackURL }, function(err, accessToken, refreshToken, params) {
         if (err) { return self.error(new InternalOAuthError('failed to obtain access token', err)); }
-        
+
         console.log('TOKEN');
         console.log('AT: ' + accessToken);
         console.log('RT: ' + refreshToken);
         console.log(params);
         console.log('----');
-        
+
         var idToken = params['id_token'];
         if (!idToken) { return self.error(new Error('ID Token not present in token response')); }
-        
+
         var idTokenSegments = idToken.split('.')
           , jwtClaimsStr
           , jwtClaims;
-        
+
         try {
           jwtClaimsStr = new Buffer(idTokenSegments[1], 'base64').toString();
           jwtClaims = JSON.parse(jwtClaimsStr);
         } catch (ex) {
           return self.error(ex);
         }
-        
+
         console.log(jwtClaims);
-        
+
         var iss = jwtClaims.iss;
         var sub = jwtClaims.sub;
         // Prior to OpenID Connect Basic Client Profile 1.0 - draft 22, the
@@ -128,20 +128,20 @@ Strategy.prototype.authenticate = function(req, options) {
         if (!sub) {
           sub = jwtClaims.user_id;
         }
-        
+
         // TODO: Ensure claims are validated per:
         //       http://openid.net/specs/openid-connect-basic-1_0.html#id_token
-        
-        
+
+
         self._shouldLoadUserProfile(iss, sub, function(err, load) {
           if (err) { return self.error(err); };
-          
+
           if (load) {
             var parsed = url.parse(config.userInfoURL, true);
             parsed.query['schema'] = 'openid';
             delete parsed.search;
             var userInfoURL = url.format(parsed);
-            
+
             // NOTE: We are calling node-oauth's internal `_request` function (as
             //       opposed to `get`) in order to send the access token in the
             //       `Authorization` header rather than as a query parameter.
@@ -152,20 +152,20 @@ Strategy.prototype.authenticate = function(req, options) {
             //       Setting the fifth argument of `_request` to `null` works
             //       around this issue.  I've noted this in comments here:
             //       https://github.com/ciaranj/node-oauth/issues/117
-            
+
             //oauth2.get(userInfoURL, accessToken, function (err, body, res) {
             oauth2._request("GET", userInfoURL, { 'Authorization': "Bearer " + accessToken, 'Accept': "application/json" }, null, null, function (err, body, res) {
               if (err) { return self.error(new InternalOAuthError('failed to fetch user profile', err)); }
-              
+
               console.log('PROFILE');
               console.log(body);
               console.log('-------');
-              
+
               var profile = {};
-              
+
               try {
                 var json = JSON.parse(body);
-                
+
                 profile.id = json.sub;
                 // Prior to OpenID Connect Basic Client Profile 1.0 - draft 22, the
                 // "sub" key was named "user_id".  Many providers still use the old
@@ -173,15 +173,15 @@ Strategy.prototype.authenticate = function(req, options) {
                 if (!profile.id) {
                   profile.id = json.user_id;
                 }
-                
+
                 profile.displayName = json.name;
                 profile.name = { familyName: json.family_name,
                                  givenName: json.given_name,
                                  middleName: json.middle_name };
-                
+
                 profile._raw = body;
                 profile._json = json;
-                
+
                 onProfileLoaded(profile);
               } catch(ex) {
                 return self.error(ex);
@@ -190,14 +190,14 @@ Strategy.prototype.authenticate = function(req, options) {
           } else {
             onProfileLoaded();
           }
-          
+
           function onProfileLoaded(profile) {
             function verified(err, user, info) {
               if (err) { return self.error(err); }
               if (!user) { return self.fail(info); }
               self.success(user, info);
             }
-          
+
             if (self._passReqToCallback) {
               var arity = self._verify.length;
               if (arity == 9) {
@@ -226,7 +226,7 @@ Strategy.prototype.authenticate = function(req, options) {
               }
             }
           }
-          
+
         });
       });
     });
@@ -236,17 +236,17 @@ Strategy.prototype.authenticate = function(req, options) {
     // be loaded.  The configuration is typically either pre-configured or
     // discovered dynamically.  When using dynamic discovery, a user supplies
     // their identifer as input.
-  
+
     var identifier;
     if (req.body && req.body[this._identifierField]) {
       identifier = req.body[this._identifierField];
     } else if (req.query && req.query[this._identifierField]) {
       identifier = req.query[this._identifierField];
     }
-  
+
     this.configure(identifier, function(err, config) {
       if (err) { return self.error(err); }
-      
+
       var callbackURL = options.callbackURL || config.callbackURL;
       if (callbackURL) {
         var parsed = url.parse(callbackURL);
@@ -256,7 +256,7 @@ Strategy.prototype.authenticate = function(req, options) {
           callbackURL = url.resolve(utils.originalURL(req), callbackURL);
         }
       }
-      
+
       var params = self.authorizationParams(options);
       var params = {};
       params['response_type'] = 'code';
@@ -274,11 +274,11 @@ Strategy.prototype.authenticate = function(req, options) {
       //       session key.
       //var state = options.state;
       //if (state) { params.state = state; }
-      
+
       var state = utils.uid(16);
-      
+
       // TODO: Implement support for standard OpenID Connect params (display, prompt, etc.)
-      
+
       var location = config.authorizationURL + '?' + querystring.stringify(params);
       self.redirect(location);
     });
@@ -318,7 +318,7 @@ Strategy.prototype.configure = function(identifier, done) {
   (function pass(i, err, config) {
     // an error or configuration was obtained, done
     if (err || config) { return done(err, config); }
-    
+
     var layer = stack[i];
     if (!layer) {
       // Strategy-specific functions did not result in obtaining configuration
@@ -326,7 +326,7 @@ Strategy.prototype.configure = function(identifier, done) {
       // to discover the provider's configuration.
       return setup(identifier, done);
     }
-    
+
     try {
       layer(identifier, function(e, c) { pass(i + 1, e, c); } )
     } catch (ex) {
@@ -379,5 +379,5 @@ Strategy.prototype._shouldLoadUserProfile = function(issuer, subject, done) {
 
 /**
  * Expose `Strategy`.
- */ 
+ */
 module.exports = Strategy;


### PR DESCRIPTION
To be able to use several openidconnect-strategy instances, they must have different names.

This adds an option to set a name other than 'openidconnect'.

For example, I setup one dynamic openidconnect, and one with pre-set authorizationURL, clientID etc for Google OpenID Connect (since they haven't implemented dynamic registration and to have a shortcut button).