### PR TITLE
add istanbul, generate coverage by default for `npm run test`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 # Node.js
 node_modules
 npm-debug.log
+coverage

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "chai": "1.x.x"
   },
   "scripts": {
-    "test": "NODE_PATH=./lib node_modules/.bin/mocha --reporter spec --require test/node/bootstrap test/*.test.js"
+    "test": "NODE_PATH=./lib istanbul cover node_modules/.bin/_mocha -- --reporter spec --require test/node/bootstrap test/*.test.js"
   },
   "engines": { "node": ">= 0.6.0" }
 }


### PR DESCRIPTION
this makes `npm run test` generate a coverage report (via istanbul).

any interest in this?