### PR TITLE
Fix double var declaration

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -258,7 +258,6 @@ Strategy.prototype.authenticate = function(req, options) {
       }
       
       var params = self.authorizationParams(options);
-      var params = {};
       params['response_type'] = 'code';
       params['client_id'] = config.clientID;
       params['redirect_uri'] = callbackURL;


### PR DESCRIPTION
With the current behaviour, `params` is always empty.
This small commit fix it.