### PR TITLE
Use state store to carry information from authorization request to response.

### DIFF
--- a/lib/state/session.js
+++ b/lib/state/session.js
@@ -49,7 +49,7 @@ SessionStore.prototype.store = function(req, meta, callback) {
   if (!req.session[key]) { req.session[key] = {}; }
   req.session[key].state = state;
 
-  callback(null, state);
+  callback(null, handle);
 };
 
 /**

--- a/lib/state/session.js
+++ b/lib/state/session.js
@@ -35,13 +35,20 @@ function SessionStore(options) {
  * @param {Function} callback
  * @api protected
  */
-SessionStore.prototype.store = function(req, callback) {
+SessionStore.prototype.store = function(req, meta, callback) {
   if (!req.session) { return callback(new Error('OpenID Connect authentication requires session support when using state. Did you forget to use express-session middleware?')); }
 
   var key = this._key;
-  var state = utils.uid(24);
+  var handle = utils.uid(24);
+
+  var state = { handle: handle };
+  for (entry in meta) {
+    state[entry] = meta[entry];
+  }
+
   if (!req.session[key]) { req.session[key] = {}; }
   req.session[key].state = state;
+
   callback(null, state);
 };
 
@@ -74,11 +81,11 @@ SessionStore.prototype.verify = function(req, providedState, callback) {
    delete req.session[key];
   }
 
-  if (state !== providedState) {
+  if (state.handle !== providedState) {
    return callback(null, false, { message: 'Invalid authorization request state.' });
   }
 
-  return callback(null, true);
+  return callback(null, true, state);
 };
 
 // Expose constructor.

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -80,6 +80,7 @@ Strategy.prototype.authenticate = function(req, options) {
       if (!ok) {
         return self.fail(state, 403);
       }
+
       var meta = state;
       var code = req.query.code;
 
@@ -232,12 +233,7 @@ Strategy.prototype.authenticate = function(req, options) {
 
     var state = req.query.state;
     try {
-      var arity = self._stateStore.verify.length;
-      if (arity == 4) {
-        self._stateStore.verify(req, state, meta, loaded);
-      } else { // arity == 3
-        self._stateStore.verify(req, state, loaded);
-      }
+      self._stateStore.verify(req, state, loaded);
     } catch (ex) {
       return self.error(ex);
     }
@@ -311,7 +307,7 @@ Strategy.prototype.authenticate = function(req, options) {
         if (err) { return self.error(err); }
         if (!state) { return self.error(new Error('Unable to generate required state parameter')); }
 
-        params.state = state.handle;
+        params.state = state;
         var location = config.authorizationURL + '?' + querystring.stringify(params);
         self.redirect(location);
       }

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -74,183 +74,173 @@ Strategy.prototype.authenticate = function(req, options) {
   }
   
   if (req.query && req.query.code) {
-
-    // TODO: This shouldn't be necessary and should be stored in state
-    this._setup(null, function(err, config) {
+    
+    function loaded(err, ok, state) {
       if (err) { return self.error(err); }
-    
-      var oauth2 = self._getOAuth2Client(config);
-
-      var meta = {
-        authorizationURL: oauth2._authorizeUrl,
-        tokenURL: oauth2._accessTokenUrl,
-        clientID: oauth2._clientId
+      if (!ok) {
+        return self.fail(state, 403);
       }
-    
-      function loaded(err, ok, state) {
-        if (err) { return self.error(err); }
-        if (!ok) {
-          return self.fail(state, 403);
+      var meta = state;
+      var code = req.query.code;
+
+      var oauth2 = self._getOAuth2Client(meta);
+
+      var callbackURL = options.callbackURL || meta.callbackURL;
+      if (callbackURL) {
+        var parsed = url.parse(callbackURL);
+        if (!parsed.protocol) {
+          // The callback URL is relative, resolve a fully qualified URL from the
+          // URL of the originating request.
+          callbackURL = url.resolve(utils.originalURL(req), callbackURL);
+        }
+      }
+
+      oauth2.getOAuthAccessToken(code, { grant_type: 'authorization_code', redirect_uri: callbackURL }, function(err, accessToken, refreshToken, params) {
+        if (err) { return self.error(new InternalOAuthError('failed to obtain access token', err)); }
+
+        var idToken = params['id_token'];
+        if (!idToken) { return self.error(new Error('ID Token not present in token response')); }
+
+        var idTokenSegments = idToken.split('.')
+          , jwtClaimsStr
+          , jwtClaims;
+
+        try {
+          jwtClaimsStr = new Buffer(idTokenSegments[1], 'base64').toString();
+          jwtClaims = JSON.parse(jwtClaimsStr);
+        } catch (ex) {
+          return self.error(ex);
         }
 
-        var code = req.query.code;
-                                  
-        var callbackURL = options.callbackURL || config.callbackURL;
-        if (callbackURL) {
-          var parsed = url.parse(callbackURL);
-          if (!parsed.protocol) {
-            // The callback URL is relative, resolve a fully qualified URL from the
-            // URL of the originating request.
-            callbackURL = url.resolve(utils.originalURL(req), callbackURL);
-          }
-        }
-        
-        oauth2.getOAuthAccessToken(code, { grant_type: 'authorization_code', redirect_uri: callbackURL }, function(err, accessToken, refreshToken, params) {
-          if (err) { return self.error(new InternalOAuthError('failed to obtain access token', err)); }
-          
-          var idToken = params['id_token'];
-          if (!idToken) { return self.error(new Error('ID Token not present in token response')); }
-          
-          var idTokenSegments = idToken.split('.')
-            , jwtClaimsStr
-            , jwtClaims;
-          
-          try {
-            jwtClaimsStr = new Buffer(idTokenSegments[1], 'base64').toString();
-            jwtClaims = JSON.parse(jwtClaimsStr);
-          } catch (ex) {
-            return self.error(ex);
-          }
-          
-          if (this._nonce && (!jwtClaims.nonce || jwtClaims.nonce !== this._nonce)) {
-            return self.error(new Error('Invalid nonce in id_token'));
-          }
+        var params = meta.params;
 
-          if (this._max_age && (!jwtClaims.auth_time || ((this._timestamp - this._max_age) > jwtClaims.auth_time))) {
-            return self.error(new Error('auth_time in id_token not included or too old'));
-          }
-          
-          var iss = jwtClaims.iss;
-          var sub = jwtClaims.sub;
-          // Prior to OpenID Connect Basic Client Profile 1.0 - draft 22, the
-          // "sub" claim was named "user_id".  Many providers still issue the
-          // claim under the old field, so fallback to that.
-          if (!sub) {
-            sub = jwtClaims.user_id;
-          }
-          
-          // TODO: Ensure claims are validated per:
-          //       http://openid.net/specs/openid-connect-basic-1_0.html#id_token
-          
-          
-          self._shouldLoadUserProfile(iss, sub, function(err, load) {
-            if (err) { return self.error(err); };
-            
-            if (load) {
-              var parsed = url.parse(config.userInfoURL, true);
-              parsed.query['schema'] = 'openid';
-              delete parsed.search;
-              var userInfoURL = url.format(parsed);
-              
-              // NOTE: We are calling node-oauth's internal `_request` function (as
-              //       opposed to `get`) in order to send the access token in the
-              //       `Authorization` header rather than as a query parameter.
-              //
-              //       Additionally, the master branch of node-oauth (as of
-              //       2013-02-16) will include the access token in *both* headers
-              //       and query parameters, which is a violation of the spec.
-              //       Setting the fifth argument of `_request` to `null` works
-              //       around this issue.  I've noted this in comments here:
-              //       https://github.com/ciaranj/node-oauth/issues/117
-              
-              //oauth2.get(userInfoURL, accessToken, function (err, body, res) {
-              oauth2._request("GET", userInfoURL, { 'Authorization': "Bearer " + accessToken, 'Accept': "application/json" }, null, null, function (err, body, res) {
-                if (err) { return self.error(new InternalOAuthError('failed to fetch user profile', err)); }
-                
-                var profile = {};
-                
-                try {
-                  var json = JSON.parse(body);
-                  
-                  profile.id = json.sub;
-                  // Prior to OpenID Connect Basic Client Profile 1.0 - draft 22, the
-                  // "sub" key was named "user_id".  Many providers still use the old
-                  // key, so fallback to that.
-                  if (!profile.id) {
-                    profile.id = json.user_id;
-                  }
-                  
-                  profile.displayName = json.name;
-                  profile.name = { familyName: json.family_name,
-                                   givenName: json.given_name,
-                                   middleName: json.middle_name };
-                  
-                  profile._raw = body;
-                  profile._json = json;
-                  
-                  onProfileLoaded(profile);
-                } catch(ex) {
-                  return self.error(ex);
+        if (params.nonce && (!jwtClaims.nonce || jwtClaims.nonce !== params.nonce)) {
+          return self.error(new Error('Invalid nonce in id_token'));
+        }
+
+        if (params.max_age && (!jwtClaims.auth_time || ((meta.timestamp - params.max_age) > jwtClaims.auth_time))) {
+          return self.error(new Error('auth_time in id_token not included or too old'));
+        }
+
+        var iss = jwtClaims.iss;
+        var sub = jwtClaims.sub;
+        // Prior to OpenID Connect Basic Client Profile 1.0 - draft 22, the
+        // "sub" claim was named "user_id".  Many providers still issue the
+        // claim under the old field, so fallback to that.
+        if (!sub) {
+          sub = jwtClaims.user_id;
+        }
+
+        // TODO: Ensure claims are validated per:
+        //       http://openid.net/specs/openid-connect-basic-1_0.html#id_token
+
+        self._shouldLoadUserProfile(iss, sub, function(err, load) {
+          if (err) { return self.error(err); };
+
+          if (load) {
+            var parsed = url.parse(meta.userInfoURL, true);
+            parsed.query['schema'] = 'openid';
+            delete parsed.search;
+            var userInfoURL = url.format(parsed);
+
+            // NOTE: We are calling node-oauth's internal `_request` function (as
+            //       opposed to `get`) in order to send the access token in the
+            //       `Authorization` header rather than as a query parameter.
+            //
+            //       Additionally, the master branch of node-oauth (as of
+            //       2013-02-16) will include the access token in *both* headers
+            //       and query parameters, which is a violation of the spec.
+            //       Setting the fifth argument of `_request` to `null` works
+            //       around this issue.  I've noted this in comments here:
+            //       https://github.com/ciaranj/node-oauth/issues/117
+
+            //oauth2.get(userInfoURL, accessToken, function (err, body, res) {
+            oauth2._request("GET", userInfoURL, { 'Authorization': "Bearer " + accessToken, 'Accept': "application/json" }, null, null, function (err, body, res) {
+              if (err) { return self.error(new InternalOAuthError('failed to fetch user profile', err)); }
+
+              var profile = {};
+
+              try {
+                var json = JSON.parse(body);
+
+                profile.id = json.sub;
+                // Prior to OpenID Connect Basic Client Profile 1.0 - draft 22, the
+                // "sub" key was named "user_id".  Many providers still use the old
+                // key, so fallback to that.
+                if (!profile.id) {
+                  profile.id = json.user_id;
                 }
-              });
-            } else {
-              onProfileLoaded();
+
+                profile.displayName = json.name;
+                profile.name = { familyName: json.family_name,
+                                 givenName: json.given_name,
+                                 middleName: json.middle_name };
+
+                profile._raw = body;
+                profile._json = json;
+
+                onProfileLoaded(profile);
+              } catch(ex) {
+                return self.error(ex);
+              }
+            });
+          } else {
+            onProfileLoaded();
+          }
+
+          function onProfileLoaded(profile) {
+            function verified(err, user, info) {
+              if (err) { return self.error(err); }
+              if (!user) { return self.fail(info); }
+
+              info = info || {};
+              if (state) { info.state = state; }
+              self.success(user, info);
             }
-            
-            function onProfileLoaded(profile) {
-              function verified(err, user, info) {
-                if (err) { return self.error(err); }
-                if (!user) { return self.fail(info); }
 
-                info = info || {};
-                if (state) { info.state = state; }
-                self.success(user, info);
+            if (self._passReqToCallback) {
+              var arity = self._verify.length;
+              if (arity == 9) {
+                self._verify(req, iss, sub, profile, jwtClaims, accessToken, refreshToken, params, verified);
+              } else if (arity == 8) {
+                self._verify(req, iss, sub, profile, accessToken, refreshToken, params, verified);
+              } else if (arity == 7) {
+                self._verify(req, iss, sub, profile, accessToken, refreshToken, verified);
+              } else if (arity == 5) {
+                self._verify(req, iss, sub, profile, verified);
+              } else { // arity == 4
+                self._verify(req, iss, sub, verified);
               }
-            
-              if (self._passReqToCallback) {
-                var arity = self._verify.length;
-                if (arity == 9) {
-                  self._verify(req, iss, sub, profile, jwtClaims, accessToken, refreshToken, params, verified);
-                } else if (arity == 8) {
-                  self._verify(req, iss, sub, profile, accessToken, refreshToken, params, verified);
-                } else if (arity == 7) {
-                  self._verify(req, iss, sub, profile, accessToken, refreshToken, verified);
-                } else if (arity == 5) {
-                  self._verify(req, iss, sub, profile, verified);
-                } else { // arity == 4
-                  self._verify(req, iss, sub, verified);
-                }
-              } else {
-                var arity = self._verify.length;
-                if (arity == 8) {
-                  self._verify(iss, sub, profile, jwtClaims, accessToken, refreshToken, params, verified);
-                } else if (arity == 7) {
-                  self._verify(iss, sub, profile, accessToken, refreshToken, params, verified);
-                } else if (arity == 6) {
-                  self._verify(iss, sub, profile, accessToken, refreshToken, verified);
-                } else if (arity == 4) {
-                  self._verify(iss, sub, profile, verified);
-                } else { // arity == 3
-                  self._verify(iss, sub, verified);
-                }
+            } else {
+              var arity = self._verify.length;
+              if (arity == 8) {
+                self._verify(iss, sub, profile, jwtClaims, accessToken, refreshToken, params, verified);
+              } else if (arity == 7) {
+                self._verify(iss, sub, profile, accessToken, refreshToken, params, verified);
+              } else if (arity == 6) {
+                self._verify(iss, sub, profile, accessToken, refreshToken, verified);
+              } else if (arity == 4) {
+                self._verify(iss, sub, profile, verified);
+              } else { // arity == 3
+                self._verify(iss, sub, verified);
               }
-            } // onProfileLoaded    
-          }); // self._shouldLoadUserProfile
-        }); // oauth2.getOAuthAccessToken
-      } // loaded
+            }
+          } // onProfileLoaded    
+        }); // self._shouldLoadUserProfile
+      }); // oauth2.getOAuthAccessToken
+    } // loaded
 
-      var state = req.query.state;
-      try {
-        var arity = self._stateStore.verify.length;
-        if (arity == 4) {
-          self._stateStore.verify(req, state, meta, loaded);
-        } else { // arity == 3
-          self._stateStore.verify(req, state, loaded);
-        }
-      } catch (ex) {
-        return self.error(ex);
+    var state = req.query.state;
+    try {
+      var arity = self._stateStore.verify.length;
+      if (arity == 4) {
+        self._stateStore.verify(req, state, meta, loaded);
+      } else { // arity == 3
+        self._stateStore.verify(req, state, loaded);
       }
-    }); // this.configure
+    } catch (ex) {
+      return self.error(ex);
+    }
   } else {
     // The request being authenticated is initiating OpenID Connect
     // authentication.  Prior to redirecting to the provider, configuration will
@@ -271,14 +261,8 @@ Strategy.prototype.authenticate = function(req, options) {
       if (err) { return self.error(err); }
 
       // Required Parameters
-      
-      var meta = {
-        issuer: config.issuer,
-        authorizationURL: config.authorizationURL,
-        tokenURL: config.tokenURL,
-        clientID: config.clientID
-      }
-      
+      var meta = config;
+
       var callbackURL = options.callbackURL || config.callbackURL;
       if (callbackURL) {
         var parsed = url.parse(callbackURL);
@@ -288,7 +272,8 @@ Strategy.prototype.authenticate = function(req, options) {
           callbackURL = url.resolve(utils.originalURL(req), callbackURL);
         }
       }
-      
+      meta.callbackURL = callbackURL;
+
       var params = self.authorizationParams(options);
       params['response_type'] = 'code';
       params['client_id'] = config.clientID;
@@ -313,9 +298,12 @@ Strategy.prototype.authenticate = function(req, options) {
       if (config.nonce && typeof config.nonce === 'number') { params.nonce = utils.uid(config.nonce); }
       if (config.nonce && typeof config.nonce === 'string') { params.nonce = config.nonce; }
 
-      if (params.nonce) this._nonce = params.nonce;
-      if (params.max_age) { this._max_age = params.max_age;
-                            this._timestamp = Math.floor(Date.now() / 1000); }
+      if (params.max_age) meta.timestamp = Math.floor(Date.now() / 1000);
+
+      meta.params = params;
+      for (param in params) {
+        if (meta[param]) delete meta[param]; // Remove redundant information.
+      }
 
       // State Storage/Management
 
@@ -323,7 +311,7 @@ Strategy.prototype.authenticate = function(req, options) {
         if (err) { return self.error(err); }
         if (!state) { return self.error(new Error('Unable to generate required state parameter')); }
 
-        params.state = state;
+        params.state = state.handle;
         var location = config.authorizationURL + '?' + querystring.stringify(params);
         self.redirect(location);
       }

--- a/test/openidconnect.state.custom.test.js
+++ b/test/openidconnect.state.custom.test.js
@@ -22,18 +22,26 @@ describe('custom store', function() {
       return cb(null, 'foos7473');
     };
     
-    CustomStore.prototype.verify = function(req, state, meta, cb) {
+    CustomStore.prototype.verify = function(req, state, cb) {
       if (req.url === '/error') { return cb(new Error('something went wrong verifying state')); }
       if (req.url === '/exception') { throw new Error('something went horribly wrong verifying state'); }
       
       if (req.url !== '/auth/example/callback') { return cb(new Error('incorrect req argument')); }
       if (state !== 'foos7473') { return cb(new Error('incorrect state argument')); }
-      if (meta.authorizationURL !== 'https://www.example.com/oauth2/authorize') { return cb(new Error('incorrect meta.authorizationURL argument')); }
-      if (meta.tokenURL !== 'https://www.example.com/oauth2/token') { return cb(new Error('incorrect meta.tokenURL argument')); }
-      if (meta.clientID !== 'ABC123') { return callback(new Error('incorrect meta.clientID argument')); }
+
+      var storedInfo = {
+        userInfoURL: 'https://www.example.com/oauth2/userinfo',
+        tokenURL: 'https://www.example.com/oauth2/token',
+        clientID: 'ABC123',
+        clientSecret: 'secret',
+        callbackURL: 'https://www.example.net/auth/example/callback',
+        params: {
+          state: 'foos7473'
+        }
+      }
       
       req.customStoreVerifyCalled = req.customStoreVerifyCalled ? req.customStoreVerifyCalled++ : 1;
-      return cb(null, true);
+      return cb(null, true, storedInfo);
     };
     
     
@@ -259,6 +267,7 @@ describe('custom store', function() {
         });
 
         it('should error', function() {
+          console.log(err);
           expect(err).to.be.an.instanceof(Error);
           expect(err.message).to.equal('something went horribly wrong verifying state');
         });
@@ -273,9 +282,22 @@ describe('custom store', function() {
     function CustomStore() {
     }
     
-    CustomStore.prototype.verify = function(req, state, meta, cb) {
+    CustomStore.prototype.verify = function(req, state, cb) {
+
+      var storedInfo = {
+        userInfoURL: 'https://www.example.com/oauth2/userinfo',
+        tokenURL: 'https://www.example.com/oauth2/token',
+        clientID: 'ABC123',
+        clientSecret: 'secret',
+        callbackURL: 'https://www.example.net/auth/example/callback',
+        params: {
+          state: 'foos7473'
+        },
+        returnTo: 'http://www.example.com/'
+      }
+
       req.customStoreVerifyCalled = req.customStoreVerifyCalled ? req.customStoreVerifyCalled++ : 1;
-      return cb(null, true, { returnTo: 'http://www.example.com/' });
+      return cb(null, true, storedInfo);
     };
     
     describe('processing response to authorization request', function() {

--- a/test/openidconnect.state.session.test.js
+++ b/test/openidconnect.state.session.test.js
@@ -43,8 +43,15 @@ describe('session store', function() {
         it('should save state in session', function() {
           var u = uri.parse(url, true);
         
-          expect(request.session['openidconnect:www.example.com'].state).to.have.length(24);
-          expect(request.session['openidconnect:www.example.com'].state).to.equal(u.query.state);
+          expect(request.session['openidconnect:www.example.com'].state.handle).to.have.length(24);
+          expect(request.session['openidconnect:www.example.com'].state.handle).to.equal(u.query.state);
+
+          expect(request.session['openidconnect:www.example.com'].state.authorizationURL).to.equal('https://www.example.com/oauth2/authorize');
+          expect(request.session['openidconnect:www.example.com'].state.tokenURL).to.equal('https://www.example.com/oauth2/token');
+          expect(request.session['openidconnect:www.example.com'].state.clientID).to.equal('ABC123');
+          expect(request.session['openidconnect:www.example.com'].state.clientSecret).to.equal('secret');
+          expect(request.session['openidconnect:www.example.com'].state.callbackURL).to.equal('https://www.example.net/auth/example/callback')
+          expect(request.session['openidconnect:www.example.com'].state.params.response_type).to.equal('code');
         });
       }); // that redirects to service provider
       
@@ -74,8 +81,15 @@ describe('session store', function() {
         it('should save state in session', function() {
           var u = uri.parse(url, true);
         
-          expect(request.session['openidconnect:www.example.com'].state).to.have.length(24);
-          expect(request.session['openidconnect:www.example.com'].state).to.equal(u.query.state);
+          expect(request.session['openidconnect:www.example.com'].state.handle).to.have.length(24);
+          expect(request.session['openidconnect:www.example.com'].state.handle).to.equal(u.query.state);
+          
+          expect(request.session['openidconnect:www.example.com'].state.authorizationURL).to.equal('https://www.example.com/oauth2/authorize');
+          expect(request.session['openidconnect:www.example.com'].state.tokenURL).to.equal('https://www.example.com/oauth2/token');
+          expect(request.session['openidconnect:www.example.com'].state.clientID).to.equal('ABC123');
+          expect(request.session['openidconnect:www.example.com'].state.clientSecret).to.equal('secret');
+          expect(request.session['openidconnect:www.example.com'].state.callbackURL).to.equal('https://www.example.net/auth/example/callback')
+          expect(request.session['openidconnect:www.example.com'].state.params.response_type).to.equal('code');
         });
         
         it('should preserve other data in session', function() {
@@ -179,7 +193,21 @@ describe('session store', function() {
               req.query.state = 'DkbychwKu8kBaJoLE5yeR5NK';
               req.session = {};
               req.session['openidconnect:www.example.com'] = {};
-              req.session['openidconnect:www.example.com']['state'] = 'DkbychwKu8kBaJoLE5yeR5NK';
+              req.session['openidconnect:www.example.com']['state'] = {
+                handle: 'DkbychwKu8kBaJoLE5yeR5NK',
+                authorizationURL: 'https://www.example.com/oauth2/authorize',
+                userInfoURL: 'https://www.example.com/oauth2/userinfo',
+                tokenURL: 'https://www.example.com/oauth2/token',
+                clientID: 'ABC123',
+                clientSecret: 'secret',
+                callbackURL: 'https://www.example.net/auth/example/callback',
+                params: {
+                  response_type: 'code',
+                  client_id: 'ABC123',
+                  redirect_uri: 'https://www.example.net/auth/example/callback',
+                  scope: 'openid'
+                }
+              };
             })
             .authenticate();
         });
@@ -219,7 +247,21 @@ describe('session store', function() {
               req.query.state = 'DkbychwKu8kBaJoLE5yeR5NK';
               req.session = {};
               req.session['openidconnect:www.example.com'] = {};
-              req.session['openidconnect:www.example.com']['state'] = 'DkbychwKu8kBaJoLE5yeR5NK';
+              req.session['openidconnect:www.example.com']['state'] = {
+                handle: 'DkbychwKu8kBaJoLE5yeR5NK',
+                authorizationURL: 'https://www.example.com/oauth2/authorize',
+                userInfoURL: 'https://www.example.com/oauth2/userinfo',
+                tokenURL: 'https://www.example.com/oauth2/token',
+                clientID: 'ABC123',
+                clientSecret: 'secret',
+                callbackURL: 'https://www.example.net/auth/example/callback',
+                params: {
+                  response_type: 'code',
+                  client_id: 'ABC123',
+                  redirect_uri: 'https://www.example.net/auth/example/callback',
+                  scope: 'openid'
+                }
+              };
               req.session['openidconnect:www.example.com'].foo = 'bar';
             })
             .authenticate();
@@ -260,7 +302,21 @@ describe('session store', function() {
               req.query.state = 'DkbychwKu8kBaJoLE5yeR5NK-WRONG';
               req.session = {};
               req.session['openidconnect:www.example.com'] = {};
-              req.session['openidconnect:www.example.com']['state'] = 'DkbychwKu8kBaJoLE5yeR5NK';
+              req.session['openidconnect:www.example.com']['state'] = {
+                handle: 'DkbychwKu8kBaJoLE5yeR5NK',
+                authorizationURL: 'https://www.example.com/oauth2/authorize',
+                userInfoURL: 'https://www.example.com/oauth2/userinfo',
+                tokenURL: 'https://www.example.com/oauth2/token',
+                clientID: 'ABC123',
+                clientSecret: 'secret',
+                callbackURL: 'https://www.example.net/auth/example/callback',
+                params: {
+                  response_type: 'code',
+                  client_id: 'ABC123',
+                  redirect_uri: 'https://www.example.net/auth/example/callback',
+                  scope: 'openid'
+                }
+              };
             })
             .authenticate();
         });
@@ -455,8 +511,15 @@ describe('session store', function() {
         it('should save state in session', function() {
           var u = uri.parse(url, true);
         
-          expect(request.session['openidconnect:example'].state).to.have.length(24);
-          expect(request.session['openidconnect:example'].state).to.equal(u.query.state);
+          expect(request.session['openidconnect:example'].state.handle).to.have.length(24);
+          expect(request.session['openidconnect:example'].state.handle).to.equal(u.query.state);
+
+          expect(request.session['openidconnect:example'].state.authorizationURL).to.equal('https://www.example.com/oauth2/authorize');
+          expect(request.session['openidconnect:example'].state.tokenURL).to.equal('https://www.example.com/oauth2/token');
+          expect(request.session['openidconnect:example'].state.clientID).to.equal('ABC123');
+          expect(request.session['openidconnect:example'].state.clientSecret).to.equal('secret');
+          expect(request.session['openidconnect:example'].state.callbackURL).to.equal('https://www.example.net/auth/example/callback')
+          expect(request.session['openidconnect:example'].state.params.response_type).to.equal('code');
         });
       }); // that redirects to service provider
       
@@ -484,7 +547,21 @@ describe('session store', function() {
               req.query.state = 'DkbychwKu8kBaJoLE5yeR5NK';
               req.session = {};
               req.session['openidconnect:example'] = {};
-              req.session['openidconnect:example']['state'] = 'DkbychwKu8kBaJoLE5yeR5NK';
+              req.session['openidconnect:example']['state'] = {
+                handle: 'DkbychwKu8kBaJoLE5yeR5NK',
+                authorizationURL: 'https://www.example.com/oauth2/authorize',
+                userInfoURL: 'https://www.example.com/oauth2/userinfo',
+                tokenURL: 'https://www.example.com/oauth2/token',
+                clientID: 'ABC123',
+                clientSecret: 'secret',
+                callbackURL: 'https://www.example.net/auth/example/callback',
+                params: {
+                  response_type: 'code',
+                  client_id: 'ABC123',
+                  redirect_uri: 'https://www.example.net/auth/example/callback',
+                  scope: 'openid'
+                }
+              };
             })
             .authenticate();
         });


### PR DESCRIPTION
Instead of reconfiguring from the original setup parameters.