### PR TITLE
Fix for passing options into the utils.originalURL function

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -28,13 +28,13 @@ function Strategy(options, verify) {
   passport.Strategy.call(this);
   this.name = 'openidconnect';
   this._verify = verify;
-  
+
   // TODO: What's the recommended field name for OpenID Connect?
   this._identifierField = options.identifierField || 'openid_identifier';
   this._scope = options.scope;
   this._passReqToCallback = options.passReqToCallback;
   this._skipUserProfile = (options.skipUserProfile === undefined) ? false : options.skipUserProfile;
-  
+
   this._setup = undefined;
 
   this._key = options.sessionKey || (this.name + ':' + url.parse(options.authorizationURL).hostname);
@@ -48,6 +48,8 @@ function Strategy(options, verify) {
   } else {
     this.configure(require('./setup/dynamic')(options));
   }
+
+  this._options = options;
 }
 
 /**
@@ -244,7 +246,7 @@ Strategy.prototype.authenticate = function(req, options) {
                 self._verify(iss, sub, verified);
               }
             }
-          } // onProfileLoaded    
+          } // onProfileLoaded
         }); // self._shouldLoadUserProfile
       }); // oauth2.getOAuthAccessToken
     } // loaded
@@ -261,14 +263,14 @@ Strategy.prototype.authenticate = function(req, options) {
     // be loaded.  The configuration is typically either pre-configured or
     // discovered dynamically.  When using dynamic discovery, a user supplies
     // their identifer as input.
-  
+
     var identifier;
     if (req.body && req.body[this._identifierField]) {
       identifier = req.body[this._identifierField];
     } else if (req.query && req.query[this._identifierField]) {
       identifier = req.query[this._identifierField];
     }
-  
+
     // FIXME: Hard coded for test purposes:
     //identifier = 'acct:paulej@packetizer.com';
     this._setup(identifier, function(err, config) {
@@ -283,7 +285,7 @@ Strategy.prototype.authenticate = function(req, options) {
         if (!parsed.protocol) {
           // The callback URL is relative, resolve a fully qualified URL from the
           // URL of the originating request.
-          callbackURL = url.resolve(utils.originalURL(req), callbackURL);
+          callbackURL = url.resolve(utils.originalURL(req, self._options), callbackURL);
         }
       }
       meta.callbackURL = callbackURL;
@@ -418,5 +420,5 @@ Strategy.prototype._getOAuth2Client = function (config) {
 
 /**
  * Expose `Strategy`.
- */ 
+ */
 module.exports = Strategy;

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,135 @@
+var utils = require('../lib/utils');
+
+describe('utils', function() {
+  describe('originalUrl', function() {
+    it("can determine https from the connection encryption status", function() {
+      var req = createVanillaRequest();
+
+      expect(utils.originalURL(req)).to.equal('http://google.com/woot');
+
+      req.connection.encrypted = true;
+
+      expect(utils.originalURL(req)).to.equal('https://google.com/woot');
+    });
+
+    describe("can determine the host from the x-forwarded-host header", function() {
+      it("with no options", function() {
+        var req = createVanillaRequest();
+
+        req.headers['x-forwarded-host'] = 'yahoo.com';
+
+        expect(utils.originalURL(req)).to.equal('http://google.com/woot');
+      });
+
+      it("with the proxy option", function() {
+        var req = createVanillaRequest();
+
+        req.headers['x-forwarded-host'] = 'yahoo.com';
+
+        expect(utils.originalURL(req, { })).to.equal('http://google.com/woot');
+        expect(utils.originalURL(req, { proxy : false })).to.equal('http://google.com/woot');
+        expect(utils.originalURL(req, { proxy : null })).to.equal('http://google.com/woot');
+        expect(utils.originalURL(req, { proxy : true })).to.equal('http://yahoo.com/woot');
+      });
+
+      it("with an app object on the request", function() {
+        var req = createVanillaRequest();
+
+        req.app = {
+          get : function(name) {
+            if (name === 'trust proxy') {
+              return false;
+            }
+          }
+        };
+
+        req.headers['x-forwarded-host'] = 'yahoo.com';
+
+        expect(utils.originalURL(req)).to.equal('http://google.com/woot');
+        expect(utils.originalURL(req, { })).to.equal('http://google.com/woot');
+        expect(utils.originalURL(req, { proxy : false })).to.equal('http://google.com/woot');
+
+        req.app = {
+          get : function(name) {
+            if (name === 'trust proxy') {
+              return true;
+            }
+          }
+        };
+
+        expect(utils.originalURL(req)).to.equal('http://yahoo.com/woot');
+        expect(utils.originalURL(req), { }).to.equal('http://yahoo.com/woot');
+        expect(utils.originalURL(req), { proxy : false }).to.equal('http://yahoo.com/woot');
+        expect(utils.originalURL(req), { proxy : true }).to.equal('http://yahoo.com/woot');
+      });
+    });
+
+    describe("can determine the protocol from the x-forwarded-proto header", function() {
+      it("with no options", function() {
+        var req = createVanillaRequest();
+
+        req.headers['x-forwarded-proto'] = 'http';
+
+        expect(utils.originalURL(req)).to.equal('http://google.com/woot');
+
+        req.headers['x-forwarded-proto'] = 'https';
+
+        expect(utils.originalURL(req)).to.equal('http://google.com/woot');
+      });
+
+      it("with the proxy option", function() {
+        var req = createVanillaRequest();
+
+        req.headers['x-forwarded-proto'] = 'https';
+
+        expect(utils.originalURL(req, { })).to.equal('http://google.com/woot');
+        expect(utils.originalURL(req, { proxy : false })).to.equal('http://google.com/woot');
+        expect(utils.originalURL(req, { proxy : null })).to.equal('http://google.com/woot');
+        expect(utils.originalURL(req, { proxy : true })).to.equal('https://google.com/woot');
+      });
+
+      it("with an app object on the request", function() {
+        var req = createVanillaRequest();
+
+        req.app = {
+          get : function(name) {
+            if (name === 'trust proxy') {
+              return false;
+            }
+          }
+        };
+
+        req.headers['x-forwarded-proto'] = 'https';
+
+        expect(utils.originalURL(req)).to.equal('http://google.com/woot');
+        expect(utils.originalURL(req, { })).to.equal('http://google.com/woot');
+        expect(utils.originalURL(req, { proxy : false })).to.equal('http://google.com/woot');
+
+        req.app = {
+          get : function(name) {
+            if (name === 'trust proxy') {
+              return true;
+            }
+          }
+        };
+
+        expect(utils.originalURL(req)).to.equal('https://google.com/woot');
+        expect(utils.originalURL(req), { }).to.equal('https://google.com/woot');
+        expect(utils.originalURL(req), { proxy : false }).to.equal('https://google.com/woot');
+        expect(utils.originalURL(req), { proxy : true }).to.equal('https://google.com/woot');
+      });
+    });
+  });
+});
+
+function createVanillaRequest() {
+  return {
+    headers : {
+      host : 'google.com'
+    },
+    connection : {
+      encrypted : null
+    },
+    url : '/woot'
+  };
+}


### PR DESCRIPTION
I found an issue when attempting to use this library behind a proxy and found that it was not passing my main options object through to the utils.originalURL function so it could determine if it should trust the x-forwarded-host and x-forwarded-proto headers in the request.

I have added some rudimentary tests over the originalURL function aswell to make sure its functionality cannot be changed without being noticed.