### PR TITLE
Added passing of configured agent through to the oauth2 object

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -89,6 +89,12 @@ Strategy.prototype.authenticate = function(req, options) {
 
       var oauth2 = self._getOAuth2Client(meta);
 
+      //if an agent is provided and our oauth2 object supports the setting of an
+      //agent - do so
+      if (options.agent && oauth2.setAgent) {
+        oauth2.setAgent(options.agent);
+      }
+
       oauth2.getOAuthAccessToken(code, { grant_type: 'authorization_code', redirect_uri: callbackURL }, function(err, accessToken, refreshToken, params) {
         if (err) { return self.error(new InternalOAuthError('failed to obtain access token', err)); }
 


### PR DESCRIPTION
In order to use this with servers utilising HTTPS certificates that do not appear in the global ca_certs within node, you need to construct a custom agent and use it for any HTTPS requests.

I have updated the oauth2 library (0.9.15) to add this ability, and I have added in the small snippet of code below to pass through any given agent to that library.

No test coverage.