### PR TITLE
minor typ0

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -116,7 +116,7 @@ Strategy.prototype.authenticate = function(req, options) {
         // https://openid.net/specs/openid-connect-basic-1_0.html#IDTokenValidation - checks 2 and 3.
         if (typeof jwtClaims.aud === 'string') {
           if (jwtClaims.aud !== meta.clientID) return self.error(new Error('aud parameter does not include this client - is: '
-                                                                           + jwtClaims.aud + '| expected: ' + meta.clientID));
+                                                                           + jwtClaims.aud + ' | expected: ' + meta.clientID));
         } else if (Array.isArray(jwtClaims.aud)) {
           if (jwtClaims.aud.indexOf(meta.clientID) === -1) return self.error(new Error('aud parameter does not include this client - is: ' +
                                                                                        jwtClaims.aud + ' | expected to include: ' + meta.clientID));


### PR DESCRIPTION
This adds a space between the given value and the |-seperator as with the other error messages.