### PR TITLE
feat: enable authorizationParams as defined within options

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -385,7 +385,7 @@ Strategy.prototype.configure = function(identifier, done) {
  * @api protected
  */
 Strategy.prototype.authorizationParams = function(options) {
-  return {};
+  return options;
 }
 
 /**


### PR DESCRIPTION
This enables people to use passport-openidconnect directly when
specific parameters are required instead of creating another passport
strategy. A additional parameter can be passed within the authenticate
method, e.g.
`
passport.authenticate('openidconnect', {connection: 'my-oidc'})...`