### PR TITLE
check length of aud cliam

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -120,7 +120,7 @@ Strategy.prototype.authenticate = function(req, options) {
         } else if (Array.isArray(jwtClaims.aud)) {
           if (jwtClaims.aud.indexOf(meta.clientID) === -1) return self.error(new Error('aud parameter does not include this client - is: ' +
                                                                                        jwtClaims.aud + ' | expected to include: ' + meta.clientID));
-          if (jwtClaims.length > 1 && !jwtClaims.azp) return self.error(new Error('azp parameter required with multiple audiences'));
+          if (jwtClaims.aud.length > 1 && !jwtClaims.azp) return self.error(new Error('azp parameter required with multiple audiences'));
         } else {
           return self.error(new Error('Invalid aud parameter type'));
         }


### PR DESCRIPTION
I found this reading through the implementation.  I think this what it should be.  `jwtClaims` is an object.  We are in a scope where `jwtCliams.aud` is an array.