### PR TITLE
added agent and console log the oauth2 request error

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -88,8 +88,12 @@ Strategy.prototype.authenticate = function(req, options) {
       var callbackURL = meta.callbackURL;
 
       var oauth2 = self._getOAuth2Client(meta);
+      oauth2.setAgent(meta.agent);
 
       oauth2.getOAuthAccessToken(code, { grant_type: 'authorization_code', redirect_uri: callbackURL }, function(err, accessToken, refreshToken, params) {
+        console.log('================ERROR MESSAGE====================');
+        console.log(err);
+        console.log('================ERROR MESSAGE====================');
         if (err) { return self.error(new InternalOAuthError('failed to obtain access token', err)); }
 
         var idToken = params['id_token'];


### PR DESCRIPTION
Added the ability to set your own HTTPS node agent as well as logging for OAUTH2 request errors.