### PR TITLE
Allow custom HTTP client agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,5 @@ including [Express](http://expressjs.com/).
 [The MIT License](http://opensource.org/licenses/MIT)
 
 Copyright (c) 2011-2013 Jared Hanson <[http://jaredhanson.net/](http://jaredhanson.net/)>
+
+<a target='_blank' rel='nofollow' href='https://app.codesponsor.io/link/vK9dyjRnnWsMzzJTQ57fRJpH/jaredhanson/passport-openidconnect'>  <img alt='Sponsor' width='888' height='68' src='https://app.codesponsor.io/embed/vK9dyjRnnWsMzzJTQ57fRJpH/jaredhanson/passport-openidconnect.svg' /></a>

--- a/lib/errors/authorizationerror.js
+++ b/lib/errors/authorizationerror.js
@@ -1,0 +1,44 @@
+/**
+ * `AuthorizationError` error.
+ *
+ * AuthorizationError represents an error in response to an authorization
+ * request.  For details, refer to RFC 6749, section 4.1.2.1.
+ *
+ * References:
+ *   - [The OAuth 2.0 Authorization Framework](http://tools.ietf.org/html/rfc6749)
+ *
+ * @constructor
+ * @param {String} [message]
+ * @param {String} [code]
+ * @param {String} [uri]
+ * @param {Number} [status]
+ * @api public
+ */
+function AuthorizationError(message, code, uri, status) {
+  if (!status) {
+    switch (code) {
+    case 'access_denied': status = 403; break;
+    case 'server_error': status = 502; break;
+    case 'temporarily_unavailable': status = 503; break;
+    }
+  }
+
+  Error.call(this);
+  Error.captureStackTrace(this, this.constructor);
+  this.name = this.constructor.name;
+  this.message = message;
+  this.code = code || 'server_error';
+  this.uri = uri;
+  this.status = status || 500;
+}
+
+/**
+ * Inherit from `Error`.
+ */
+AuthorizationError.prototype.__proto__ = Error.prototype;
+
+
+/**
+ * Expose `AuthorizationError`.
+ */
+module.exports = AuthorizationError;

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -34,7 +34,8 @@ function Strategy(options, verify) {
   this._scope = options.scope;
   this._passReqToCallback = options.passReqToCallback;
   this._skipUserProfile = (options.skipUserProfile === undefined) ? false : options.skipUserProfile;
-  
+  this._agent = options.agent;
+
   this._setup = undefined;
 
   this._key = options.sessionKey || (this.name + ':' + url.parse(options.authorizationURL).hostname);
@@ -88,9 +89,15 @@ Strategy.prototype.authenticate = function(req, options) {
       var callbackURL = meta.callbackURL;
 
       var oauth2 = self._getOAuth2Client(meta);
+      if (self._agent) {
+        oauth2.setAgent(self._agent)
+      }
 
       oauth2.getOAuthAccessToken(code, { grant_type: 'authorization_code', redirect_uri: callbackURL }, function(err, accessToken, refreshToken, params) {
-        if (err) { return self.error(new InternalOAuthError('failed to obtain access token', err)); }
+        if (err) {
+          console.log(err);
+          return self.error(new InternalOAuthError('failed to obtain access token', err)); 
+        }
 
         var idToken = params['id_token'];
         if (!idToken) { return self.error(new Error('ID Token not present in token response')); }

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -9,7 +9,8 @@ var passport = require('passport-strategy')
   , OAuth2 = require('oauth').OAuth2
   , SessionStateStore = require('./state/session')
   //, setup = require('./setup')
-  , InternalOAuthError = require('./errors/internaloautherror');
+  , InternalOAuthError = require('./errors/internaloautherror')
+  , AuthorizationError = require('./errors/authorizationerror');
 
 
 /**
@@ -65,15 +66,17 @@ util.inherits(Strategy, passport.Strategy);
 Strategy.prototype.authenticate = function(req, options) {
   options = options || {};
   var self = this;
-  
+
   if (req.query && req.query.error) {
-    // TODO: Error information pertaining to OAuth 2.0 flows is encoded in the
-    //       query parameters, and should be propagated to the application.
-    return this.fail();
+    if (req.query.error == 'access_denied') {
+      return this.fail({ message: req.query.error_description });
+    } else {
+      return this.error(new AuthorizationError(req.query.error_description, req.query.error, req.query.error_uri));
+    }
   }
-  
+
   if (req.query && req.query.code) {
-    
+
     function loaded(err, ok, state) {
       if (err) { return self.error(err); }
       if (!ok) {

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -150,9 +150,6 @@ Strategy.prototype.authenticate = function(req, options) {
           sub = jwtClaims.user_id;
         }
 
-        // TODO: Ensure claims are validated per:
-        //       http://openid.net/specs/openid-connect-basic-1_0.html#id_token
-
         self._shouldLoadUserProfile(iss, sub, function(err, load) {
           if (err) { return self.error(err); };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-openidconnect",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "OpenID Connect authentication strategy for Passport.",
   "keywords": [
     "passport",


### PR DESCRIPTION
- Provided an `_agent` option to be passed into OAuth2
- Added a console log for the `getOAuthAccessToken` callback as the `AuthorizationError` was obfuscating the stack trace.

Forgive the merged commits, my attempt to squash using rebase somehow produced this interesting artifact.