### PR TITLE
handle unauthorized_client error

### DIFF
--- a/lib/errors/authorizationerror.js
+++ b/lib/errors/authorizationerror.js
@@ -18,6 +18,7 @@ function AuthorizationError(message, code, uri, status) {
   if (!status) {
     switch (code) {
     case 'access_denied': status = 403; break;
+    case 'unauthorized_client': status = 403; break;
     case 'server_error': status = 502; break;
     case 'temporarily_unavailable': status = 503; break;
     }


### PR DESCRIPTION
When client is not registered with OP, and sends auth request, `https://github.com/jaredhanson/oauth2orize` replies with an error to the callback URI. The error parameter in this request is `?error=unauthorized_client`. This value is not recognized in `passport-openidconnect` and therefore client receives http status: 500. Client should receive status: 403