### PR TITLE
add option to pass custom headers to oauth2 object

### DIFF
--- a/lib/setup/manual.js
+++ b/lib/setup/manual.js
@@ -11,7 +11,8 @@ exports = module.exports = function(options) {
       userInfoURL: options.userInfoURL,
       clientID: options.clientID,
       clientSecret: options.clientSecret,
-      callbackURL: options.callbackURL
+      callbackURL: options.callbackURL,
+      customHeaders: options.customHeaders,
     }
 
     Object.keys(options).map(opt => {

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -413,7 +413,8 @@ Strategy.prototype._shouldLoadUserProfile = function(issuer, subject, done) {
 
 Strategy.prototype._getOAuth2Client = function (config) {
   return new OAuth2(config.clientID, config.clientSecret,
-                    '', config.authorizationURL, config.tokenURL);
+                    '', config.authorizationURL, config.tokenURL,
+                    config.customHeaders);
 }
 
 /**


### PR DESCRIPTION
A `Client-ID` header was required for the an endpoint I was using. This is implemented in [passport-oauth2](https://github.com/jaredhanson/passport-oauth2/blob/5d964b1d620ee0ae55b3f3d5154033dd394f4c7b/lib/strategy.js#L96) so I figured this would be useful to add in general.