### PR TITLE
use arity of the user provided verify-function

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -28,6 +28,7 @@ function Strategy(options, verify) {
   passport.Strategy.call(this);
   this.name = 'openidconnect';
   this._verify = verify;
+  this._verifyArity = (options.verify || verify).length;
   
   // TODO: What's the recommended field name for OpenID Connect?
   this._identifierField = options.identifierField || 'openid_identifier';
@@ -218,7 +219,7 @@ Strategy.prototype.authenticate = function(req, options) {
             }
 
             if (self._passReqToCallback) {
-              var arity = self._verify.length;
+              var arity = self._verifyArity;
               if (arity == 9) {
                 self._verify(req, iss, sub, profile, jwtClaims, accessToken, refreshToken, params, verified);
               } else if (arity == 8) {
@@ -231,7 +232,7 @@ Strategy.prototype.authenticate = function(req, options) {
                 self._verify(req, iss, sub, verified);
               }
             } else {
-              var arity = self._verify.length;
+              var arity = self._verifyArity;
               if (arity == 8) {
                 self._verify(iss, sub, profile, jwtClaims, accessToken, refreshToken, params, verified);
               } else if (arity == 7) {


### PR DESCRIPTION
we are currently using the passport-openidconnect strategy for the authentication in node-red. 
Because node-red wraps the verify-callback in another function when creating the strategy, which has an arity of 0, our verify-callback always gets called with only three arguments. As result we can neither have access to the user's profile  nor to the tokens.

Here is a link:
https://github.com/node-red/node-red/blob/f1e7ec0c6bc33d4d0f6286012ef4d5aa817ac0b5/packages/node_modules/%40node-red/editor-api/lib/auth/index.js#L177-L196