### PR TITLE
Meet passport profile specification

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -191,9 +191,11 @@ Strategy.prototype.authenticate = function(req, options) {
                 }
 
                 profile.displayName = json.name;
+                profile.username = json.preferred_username;
                 profile.name = { familyName: json.family_name,
                                  givenName: json.given_name,
                                  middleName: json.middle_name };
+                profile.emails = [{ value: json.email }];
 
                 profile._raw = body;
                 profile._json = json;


### PR DESCRIPTION
Add `profile.emails` and `profile.username` to make the module compatibile with http://www.passportjs.org/docs/profile/ 