### PR TITLE
Bug Fix: 'openid' added to scope even if already present 

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -291,8 +291,10 @@ Strategy.prototype.authenticate = function(req, options) {
     if (callbackURL) { params.redirect_uri = callbackURL; }
     var scope = options.scope || this._scope;
     if (scope) {
-      if (Array.isArray(scope)) { scope = scope.join(' '); }
-      params.scope = 'openid ' + scope;
+      if (Array.isArray(scope)) {
+        if (!scope.includes('openid')) { scope.unshift('openid'); }
+        params.scope = scope.join(' ');
+      }
     } else {
       params.scope = 'openid';
     }


### PR DESCRIPTION
This plugin adds the 'openid' scope to the request, even if that scope is already included, this can cause https://github.com/Ylianst/MeshCentral/issues/4493 with some IdPs. (#98)

This pull fixes the problem by adding a check while building the params to see if 'openid' is already present in the scope, adding it if necessary. 

This is tested and working with a combination of [Meshcentral](https://github.com/Ylianst/MeshCentral) and [Authelia](https://github.com/authelia/authelia)