### PR TITLE
Add Picture field to Profile

### DIFF
--- a/lib/profile.js
+++ b/lib/profile.js
@@ -17,7 +17,7 @@ exports.parse = function(json) {
     if (json.middle_name) { profile.name.middleName = json.middle_name; }
   }
   if (json.email) { profile.emails = [ { value: json.email } ]; }
-  if (json.picture) { profile.photos = [{ value: json.picture }]; }
+  if (json.picture) { profile.photos = [ { value: json.picture } ]; }
   
   return profile;
 };

--- a/lib/profile.js
+++ b/lib/profile.js
@@ -17,6 +17,7 @@ exports.parse = function(json) {
     if (json.middle_name) { profile.name.middleName = json.middle_name; }
   }
   if (json.email) { profile.emails = [ { value: json.email } ]; }
+  if (json.picture) { profile.photos = [{ value: json.picture }]; }
   
   return profile;
 };

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -417,6 +417,7 @@ describe('verify function', function() {
           displayName: 'Jane Doe',
           name: { familyName: 'Doe', givenName: 'Jane' },
           emails: [ { value: 'janedoe@example.com' } ],
+          photos: [ { value: 'http://example.com/janedoe/me.jpg' } ],
           _json: {
             sub: '248289761001',
             name: 'Jane Doe',
@@ -513,7 +514,8 @@ describe('verify function', function() {
           username: 'j.doe',
           displayName: 'Jane Doe',
           name: { familyName: 'Doe', givenName: 'Jane' },
-          emails: [ { value: 'janedoe@example.com' } ]
+          emails: [ { value: 'janedoe@example.com' } ],
+          photos: [ { value: 'http://example.com/janedoe/me.jpg' } ]
         });
         
         return cb(null, { id: '248289761001' });
@@ -588,7 +590,8 @@ describe('verify function', function() {
           username: 'j.doe',
           displayName: 'Jane Doe',
           name: { familyName: 'Doe', givenName: 'Jane' },
-          emails: [ { value: 'janedoe@example.com' } ]
+          emails: [ { value: 'janedoe@example.com' } ],
+          photos: [ { value: 'http://example.com/janedoe/me.jpg' } ]
         });
         expect(context).to.deep.equal({});
         
@@ -664,7 +667,8 @@ describe('verify function', function() {
           username: 'j.doe',
           displayName: 'Jane Doe',
           name: { familyName: 'Doe', givenName: 'Jane' },
-          emails: [ { value: 'janedoe@example.com' } ]
+          emails: [ { value: 'janedoe@example.com' } ],
+          photos: [ { value: 'http://example.com/janedoe/me.jpg' } ]
         });
         expect(context).to.deep.equal({});
         expect(idToken).to.equal('eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3NlcnZlci5leGFtcGxlLmNvbSIsInN1YiI6IjI0ODI4OTc2MTAwMSIsImF1ZCI6InM2QmhkUmtxdDMiLCJleHAiOjEzMTEyODE5NzAsImlhdCI6MTMxMTI4MDk3MH0.2Y-uXE7I6Gfon1v4mZVCRKIfZJ_I8BGQoedagok5MNk');
@@ -743,7 +747,8 @@ describe('verify function', function() {
           username: 'j.doe',
           displayName: 'Jane Doe',
           name: { familyName: 'Doe', givenName: 'Jane' },
-          emails: [ { value: 'janedoe@example.com' } ]
+          emails: [ { value: 'janedoe@example.com' } ],
+          photos: [ { value: 'http://example.com/janedoe/me.jpg' } ]
         });
         expect(context).to.deep.equal({});
         expect(idToken).to.equal('eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3NlcnZlci5leGFtcGxlLmNvbSIsInN1YiI6IjI0ODI4OTc2MTAwMSIsImF1ZCI6InM2QmhkUmtxdDMiLCJleHAiOjEzMTEyODE5NzAsImlhdCI6MTMxMTI4MDk3MH0.2Y-uXE7I6Gfon1v4mZVCRKIfZJ_I8BGQoedagok5MNk');
@@ -910,6 +915,7 @@ describe('verify function', function() {
           displayName: 'Jane Doe',
           name: { familyName: 'Doe', givenName: 'Jane' },
           emails: [ { value: 'janedoe@example.com' } ],
+          photos: [ { value: 'http://example.com/janedoe/me.jpg' } ],
           _json: {
             sub: '248289761001',
             name: 'Jane Doe',
@@ -1008,7 +1014,8 @@ describe('verify function', function() {
           username: 'j.doe',
           displayName: 'Jane Doe',
           name: { familyName: 'Doe', givenName: 'Jane' },
-          emails: [ { value: 'janedoe@example.com' } ]
+          emails: [ { value: 'janedoe@example.com' } ],
+          photos: [ { value: 'http://example.com/janedoe/me.jpg' } ]
         });
         
         return cb(null, { id: '248289761001' });
@@ -1085,7 +1092,8 @@ describe('verify function', function() {
           username: 'j.doe',
           displayName: 'Jane Doe',
           name: { familyName: 'Doe', givenName: 'Jane' },
-          emails: [ { value: 'janedoe@example.com' } ]
+          emails: [ { value: 'janedoe@example.com' } ],
+          photos: [ { value: 'http://example.com/janedoe/me.jpg' } ]
         });
         expect(context).to.deep.equal({});
         
@@ -1163,7 +1171,8 @@ describe('verify function', function() {
           username: 'j.doe',
           displayName: 'Jane Doe',
           name: { familyName: 'Doe', givenName: 'Jane' },
-          emails: [ { value: 'janedoe@example.com' } ]
+          emails: [ { value: 'janedoe@example.com' } ],
+          photos: [ { value: 'http://example.com/janedoe/me.jpg' } ]
         });
         expect(context).to.deep.equal({});
         expect(idToken).to.equal('eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3NlcnZlci5leGFtcGxlLmNvbSIsInN1YiI6IjI0ODI4OTc2MTAwMSIsImF1ZCI6InM2QmhkUmtxdDMiLCJleHAiOjEzMTEyODE5NzAsImlhdCI6MTMxMTI4MDk3MH0.2Y-uXE7I6Gfon1v4mZVCRKIfZJ_I8BGQoedagok5MNk');
@@ -1242,7 +1251,8 @@ describe('verify function', function() {
           username: 'j.doe',
           displayName: 'Jane Doe',
           name: { familyName: 'Doe', givenName: 'Jane' },
-          emails: [ { value: 'janedoe@example.com' } ]
+          emails: [ { value: 'janedoe@example.com' } ],
+          photos: [ { value: 'http://example.com/janedoe/me.jpg' } ]
         });
         expect(context).to.deep.equal({});
         expect(idToken).to.equal('eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3NlcnZlci5leGFtcGxlLmNvbSIsInN1YiI6IjI0ODI4OTc2MTAwMSIsImF1ZCI6InM2QmhkUmtxdDMiLCJleHAiOjEzMTEyODE5NzAsImlhdCI6MTMxMTI4MDk3MH0.2Y-uXE7I6Gfon1v4mZVCRKIfZJ_I8BGQoedagok5MNk');
@@ -1323,7 +1333,8 @@ describe('verify function', function() {
           username: 'j.doe',
           displayName: 'Jane Doe',
           name: { familyName: 'Doe', givenName: 'Jane' },
-          emails: [ { value: 'janedoe@example.com' } ]
+          emails: [ { value: 'janedoe@example.com' } ],
+          photos: [ { value: 'http://example.com/janedoe/me.jpg' } ]
         });
         expect(context).to.deep.equal({});
         expect(idToken).to.equal('eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3NlcnZlci5leGFtcGxlLmNvbSIsInN1YiI6IjI0ODI4OTc2MTAwMSIsImF1ZCI6InM2QmhkUmtxdDMiLCJleHAiOjEzMTEyODE5NzAsImlhdCI6MTMxMTI4MDk3MH0.2Y-uXE7I6Gfon1v4mZVCRKIfZJ_I8BGQoedagok5MNk');


### PR DESCRIPTION
This pull adds a photos field to profile. Picture according to OpenID specification should contain a url to a users profile picture.

This pull should also solve [this issue](https://github.com/jaredhanson/passport-google-openidconnect/issues/4) on `passport-google-oidc`.

The pull modifies relevant tests that check the validity of the profile field.