### PR TITLE
Added groups to profile scope.

### DIFF
--- a/lib/profile.js
+++ b/lib/profile.js
@@ -17,6 +17,7 @@ exports.parse = function(json) {
     if (json.middle_name) { profile.name.middleName = json.middle_name; }
   }
   if (json.email) { profile.emails = [ { value: json.email } ]; }
+  if (json.groups) { profile.groups = [ { value: json.groups } ]; }
   
   return profile;
 };


### PR DESCRIPTION
Some authentication providers such as Authentik supply the groups through the profile scope. This is not present in the profile object supplied by passport-openidconnect. I've added the object to the profile object. (Tested in my own environment and seems to work flawlessly)