### PR TITLE
Added specifying scope in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ passport.use(new OpenIDConnectStrategy({
     userInfoURL: 'https://server.example.com/userinfo',
     clientID: process.env['CLIENT_ID'],
     clientSecret: process.env['CLIENT_SECRET'],
-    callbackURL: 'https://client.example.org/cb'
+    callbackURL: 'https://client.example.org/cb',
+    scope: [ 'profile' ]
   },
   function verify(issuer, profile, cb) {
     db.get('SELECT * FROM federated_credentials WHERE provider = ? AND subject = ?', [


### PR DESCRIPTION
Added scope option to the example in the README. Unless I overlooked something obvious, it wasn't very apparent that you had the option to do this unless you dig through the code (e.g. the test suite).