### PR TITLE
Handle State encoding issue inbound from Provider

### DIFF
--- a/lib/state/session.js
+++ b/lib/state/session.js
@@ -82,6 +82,10 @@ SessionStore.prototype.verify = function(req, handle, cb) {
    delete req.session[key];
   }
 
+  //handle providers (AWS Cognito) that don't properly encode the + [plus sign] (%2B) char in the state
+  // query parameter. This results in a space in the handle. Must replace with + char
+  handle = handle.replace(/\s/g, '+');
+
   if (state.handle !== handle) {
    return cb(null, false, { message: 'Invalid authorization request state.' });
   }

--- a/test/store/session.test.js
+++ b/test/store/session.test.js
@@ -352,7 +352,29 @@ describe('SessionStore', function() {
         })
         .authenticate();
     }); // should error when app does not have session support
-    
+
+    it('should replace whitespace characters with + character in state handle', function(done) {
+      chai.passport.use(strategy)
+          .request(function(req) {
+            req.query = {
+              code: 'SplxlOBeZQQYbYS6WxSbIA',
+              state: 'af 0ifjsld kj'
+            };
+            req.session = {};
+            req.session['openidconnect:server.example.com'] = {
+              state: {
+                handle: 'af+0ifjsld+kj'
+              }
+            };
+          })
+          .success(function(user, info) {
+            expect(this.session['openidconnect:server.example.com']).to.be.undefined;
+            done();
+          })
+          .error(done)
+          .authenticate();
+    });
+
   }); // #verify
   
 });


### PR DESCRIPTION
This fix updates `SessionStore.verify` to convert whitespace into the `+` character. 

This is to resolve an issue with the way AWS Cognito returns the state on the querystring. Cognito does not properly encode the `+` char to `%2B`. This causes the query string state to become a whitespace char.  The failure occurs when the verify function does an equality check against inbound query string state and the session state.

#### example:

**inbound query string state** : `asd hfds j`
**original session state** : `asd+hfds+j`