### PR TITLE
fixed uid util function to generate url-safe uids

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -62,6 +62,8 @@ exports.merge = function(a, b){
  *
  * CREDIT: Connect -- utils.uid
  *         https://github.com/senchalabs/connect/blob/2.7.2/lib/utils.js
+ * 
+ * Edit: added fix so that the uid is URL safe (submitted by canuto, 23 oct)
  *
  * @param {Number} len
  * @return {String}
@@ -71,5 +73,8 @@ exports.merge = function(a, b){
 exports.uid = function(len) {
   return crypto.randomBytes(Math.ceil(len * 3 / 4))
     .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '')
     .slice(0, len);
 };


### PR DESCRIPTION
The "uid" utility function sometimes generates characters which should not be used in an URL (like '+').

This lead to a randomly occurring problem in a project I'm working on because the "state" comparison failed from time to time.